### PR TITLE
Add `ValidationT` and rename `V` to `Validation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,121 @@
 
 ## Module Data.Validation
 
-### Types
+#### `Validation`
 
-    data V err result
-
-
-### Type Class Instances
-
-    instance applicativeV :: (Semigroup err) => Applicative (V err)
-
-    instance applyV :: (Semigroup err) => Apply (V err)
-
-    instance functorV :: Functor (V err)
-
-    instance showV :: (Show err, Show result) => Show (V err result)
+``` purescript
+data Validation err result
+```
 
 
-### Values
+#### `invalid`
 
-    invalid :: forall err result. err -> V err result
+``` purescript
+invalid :: forall err result. err -> Validation err result
+```
 
-    isValid :: forall err result r. V err result -> Boolean
 
-    runV :: forall err result r. (err -> r) -> (result -> r) -> V err result -> r
+#### `runValidation`
+
+``` purescript
+runValidation :: forall err result r. (err -> r) -> (result -> r) -> Validation err result -> r
+```
+
+
+#### `isValid`
+
+``` purescript
+isValid :: forall err result r. Validation err result -> Boolean
+```
+
+
+#### `showValidation`
+
+``` purescript
+instance showValidation :: (Show err, Show result) => Show (Validation err result)
+```
+
+
+#### `functorValidation`
+
+``` purescript
+instance functorValidation :: Functor (Validation err)
+```
+
+
+#### `applyValidation`
+
+``` purescript
+instance applyValidation :: (Semigroup err) => Apply (Validation err)
+```
+
+
+#### `applicativeValidation`
+
+``` purescript
+instance applicativeValidation :: (Semigroup err) => Applicative (Validation err)
+```
+
+
+
+## Module Data.Validation.Trans
+
+#### `ValidationT`
+
+``` purescript
+newtype ValidationT err m a
+  = ValidationT (m (Validation err a))
+```
+
+
+#### `runValidationT`
+
+``` purescript
+runValidationT :: forall m err a. (Semigroup err, Monad m) => ValidationT err m a -> m (Validation err a)
+```
+
+
+#### `monadTransValidationT`
+
+``` purescript
+instance monadTransValidationT :: (Semigroup err) => MonadTrans (ValidationT err)
+```
+
+
+#### `applyValidationT`
+
+``` purescript
+instance applyValidationT :: (Semigroup err, Apply m) => Apply (ValidationT err m)
+```
+
+
+#### `applicativeValidationT`
+
+``` purescript
+instance applicativeValidationT :: (Semigroup err, Monad m) => Applicative (ValidationT err m)
+```
+
+
+#### `functorValidationT`
+
+``` purescript
+instance functorValidationT :: (Functor m) => Functor (ValidationT err m)
+```
+
+
+#### `bindValidationT`
+
+``` purescript
+instance bindValidationT :: (Semigroup err, Monad m) => Bind (ValidationT err m)
+```
+
+
+#### `monadValidationT`
+
+``` purescript
+instance monadValidationT :: (Semigroup err, Monad m) => Monad (ValidationT err m)
+```
+
+
+
+

--- a/bower.json
+++ b/bower.json
@@ -10,5 +10,8 @@
     "bower.json",
     "Gruntfile.js",
     "package.json"
-  ]
+  ],
+  "dependencies": {
+    "purescript-transformers": "0.3.0"
+  }
 }

--- a/src/Data/Validation.purs
+++ b/src/Data/Validation.purs
@@ -1,37 +1,36 @@
-module Data.Validation (
-  V(),
-  invalid,
-  runV,
-  isValid
+module Data.Validation
+  ( Validation()
+  , invalid
+  , runValidation
+  , isValid
   ) where
 
-data V err result = Invalid err | Valid result
+data Validation err result = Invalid err | Valid result
 
-invalid :: forall err result. err -> V err result
+invalid :: forall err result. err -> Validation err result
 invalid = Invalid
 
-runV :: forall err result r. (err -> r) -> (result -> r) -> V err result -> r
-runV f _ (Invalid err) = f err
-runV _ g (Valid result) = g result
+runValidation :: forall err result r. (err -> r) -> (result -> r) -> Validation err result -> r
+runValidation f _ (Invalid err) = f err
+runValidation _ g (Valid result) = g result
 
-isValid :: forall err result r. V err result -> Boolean
+isValid :: forall err result r. Validation err result -> Boolean
 isValid (Valid _) = true
 isValid _ = false
 
-instance showV :: (Show err, Show result) => Show (V err result) where
+instance showValidation :: (Show err, Show result) => Show (Validation err result) where
   show (Invalid err) = "Invalid (" ++ show err ++ ")"
   show (Valid result) = "Valid (" ++ show result ++ ")"
 
-instance functorV :: Functor (V err) where
+instance functorValidation :: Functor (Validation err) where
   (<$>) _ (Invalid err) = Invalid err
   (<$>) f (Valid result) = Valid (f result)
 
-instance applyV :: (Semigroup err) => Apply (V err) where
+instance applyValidation :: (Semigroup err) => Apply (Validation err) where
   (<*>) (Invalid err1) (Invalid err2) = Invalid (err1 <> err2)
   (<*>) (Invalid err) _ = Invalid err
   (<*>) _ (Invalid err) = Invalid err
   (<*>) (Valid f) (Valid x) = Valid (f x)
 
-instance applicativeV :: (Semigroup err) => Applicative (V err) where
+instance applicativeValidation :: (Semigroup err) => Applicative (Validation err) where
   pure = Valid
-

--- a/src/Data/Validation/Trans.purs
+++ b/src/Data/Validation/Trans.purs
@@ -1,0 +1,31 @@
+module Data.Validation.Trans
+  ( ValidationT(..)
+  , runValidationT
+  ) where
+
+import Control.Apply (lift2)
+import Control.Monad.Trans
+import Data.Validation
+
+newtype ValidationT err m a = ValidationT (m (Validation err a))
+
+runValidationT :: forall m err a. (Semigroup err, Monad m) => ValidationT err m a -> m (Validation err a)
+runValidationT (ValidationT v) = v
+
+instance monadTransValidationT :: (Semigroup err) => MonadTrans (ValidationT err) where
+  lift m = ValidationT $ m >>= return <<< pure
+
+instance applyValidationT :: (Semigroup err, Apply m) => Apply (ValidationT err m) where
+  (<*>) (ValidationT f) (ValidationT a) = ValidationT (lift2 (<*>) f a)
+
+instance applicativeValidationT :: (Semigroup err, Monad m) => Applicative (ValidationT err m) where
+  pure = ValidationT <<< return <<< pure
+
+instance functorValidationT :: (Functor m) => Functor (ValidationT err m) where
+  (<$>) f (ValidationT m) = ValidationT $ (f <$>) <$> m
+
+instance bindValidationT :: (Semigroup err, Monad m) => Bind (ValidationT err m) where
+  (>>=) (ValidationT m) f = ValidationT $ m >>= runValidationT <<< runValidation liftErr f
+    where liftErr = ValidationT <<< return <<< invalid
+
+instance monadValidationT :: (Semigroup err, Monad m) => Monad (ValidationT err m)


### PR DESCRIPTION
* Adds a monad transformer `ValidationT` which is useful validating input values
  coming in from asynchronous computations such as `ContT` or `Rx.Observable`.

* This patch also renames the type `V` to `Validation` to be consistent with the
  monad transformer counterpart `ValidationT`.