### PR TITLE
Updates for 0.12

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,26 @@
-The MIT License (MIT)
+Copyright 2018 PureScript
 
-Copyright (c) 2014 PureScript
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,6 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-bifunctors": "#compiler/0.12",
-    "purescript-foldable-traversable": "#compiler/0.12"
+    "purescript-either": "#compiler/0.12"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,7 @@
 {
   "name": "purescript-validation",
   "homepage": "https://github.com/purescript/purescript-validation",
-  "description": "Applicative validation",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "git://github.com/purescript/purescript-validation.git"
@@ -17,6 +16,10 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-either": "#compiler/0.12"
+    "purescript-bifunctors": "^4.0.0",
+    "purescript-control": "^4.0.0",
+    "purescript-either": "^4.0.0",
+    "purescript-foldable-traversable": "^4.0.0",
+    "purescript-prelude": "^4.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -17,8 +17,7 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-bifunctors": "^3.0.0",
-    "purescript-monoid": "^3.0.0",
-    "purescript-foldable-traversable": "^3.6.1"
+    "purescript-bifunctors": "#compiler/0.12",
+    "purescript-foldable-traversable": "#compiler/0.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "pulp build -- --censor-lib --strict"
   },
   "devDependencies": {
-    "pulp": "^12.0.1",
+    "pulp": "^12.2.0",
     "purescript-psa": "^0.6.0",
     "rimraf": "^2.6.2"
   }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "build": "pulp build -- --censor-lib --strict"
   },
   "devDependencies": {
-    "pulp": "^10.0.4",
-    "purescript-psa": "^0.5.0-rc.1",
-    "rimraf": "^2.6.1"
+    "pulp": "^12.0.1",
+    "purescript-psa": "^0.6.0",
+    "rimraf": "^2.6.2"
   }
 }

--- a/src/Data/Validation/Semigroup.purs
+++ b/src/Data/Validation/Semigroup.purs
@@ -16,7 +16,6 @@ import Prelude
 import Control.Apply (lift2)
 import Data.Bifunctor (class Bifunctor)
 import Data.Foldable (class Foldable)
-import Data.Monoid (class Monoid, mempty)
 import Data.Traversable (class Traversable)
 
 -- | The `V` functor, used for applicative validation

--- a/src/Data/Validation/Semiring.purs
+++ b/src/Data/Validation/Semiring.purs
@@ -19,7 +19,6 @@ import Control.Apply (lift2)
 import Control.Plus (class Plus)
 import Data.Bifunctor (class Bifunctor)
 import Data.Foldable (class Foldable)
-import Data.Monoid (class Monoid, mempty)
 import Data.Traversable (class Traversable)
 
 -- | The `V` functor, used for alternative validation

--- a/src/Data/Validation/Semiring.purs
+++ b/src/Data/Validation/Semiring.purs
@@ -9,6 +9,7 @@ module Data.Validation.Semiring
   , unV
   , invalid
   , isValid
+  , toEither
   ) where
 
 import Prelude
@@ -18,7 +19,10 @@ import Control.Alternative (class Alternative)
 import Control.Apply (lift2)
 import Control.Plus (class Plus)
 import Data.Bifunctor (class Bifunctor)
+import Data.Either (Either(..))
+import Data.Eq (class Eq1)
 import Data.Foldable (class Foldable)
+import Data.Ord (class Ord1)
 import Data.Traversable (class Traversable)
 
 -- | The `V` functor, used for alternative validation
@@ -37,47 +41,49 @@ import Data.Traversable (class Traversable)
 -- |   <*> validateName person.last
 -- |   <*> (validateEmail person.contact <|> validatePhone person.contact)
 -- | ```
-data V err res = Valid res | Invalid err
+newtype V err result = V (Either err result)
 
 -- | Unpack the `V` type constructor, providing functions to handle the error
 -- | and success cases.
 unV :: forall err result r. (err -> r) -> (result -> r) -> V err result -> r
-unV f _ (Invalid err) = f err
-unV _ g (Valid result) = g result
+unV f _ (V (Left err)) = f err
+unV _ g (V (Right result)) = g result
 
--- | Fail with a validation error
+-- | Fail with a validation error.
 invalid :: forall err result. err -> V err result
-invalid = Invalid
+invalid = V <<< Left
 
--- | Test whether validation was successful or not
+-- | Test whether validation was successful or not.
 isValid :: forall err result. V err result -> Boolean
-isValid (Valid _) = true
+isValid (V (Right _)) = true
 isValid _ = false
 
+toEither :: forall err result. V err result -> Either err result
+toEither (V e) = e
+
 derive instance eqV :: (Eq err, Eq result) => Eq (V err result)
+derive instance eq1V :: Eq err => Eq1 (V err)
 
 derive instance ordV :: (Ord err, Ord result) => Ord (V err result)
+derive instance ord1V :: Ord err => Ord1 (V err)
 
 instance showV :: (Show err, Show result) => Show (V err result) where
-  show (Invalid err) = "Invalid (" <> show err <> ")"
-  show (Valid result) = "Valid (" <> show result <> ")"
+  show = case _ of
+    V (Left err) -> "invalid (" <> show err <> ")"
+    V (Right result) -> "pure (" <> show result <> ")"
 
-instance functorV :: Functor (V err)  where
-  map _ (Invalid err) = Invalid err
-  map f (Valid result) = Valid (f result)
+derive newtype instance functorV :: Functor (V err)
 
-instance bifunctorV :: Bifunctor V where
-  bimap f _ (Invalid err) = Invalid (f err)
-  bimap _ g (Valid result) = Valid (g result)
+derive newtype instance bifunctorV :: Bifunctor V
 
-instance applyV :: (Semiring err) => Apply (V err)  where
-  apply (Invalid err1) (Invalid err2) = Invalid (err1 * err2)
-  apply (Invalid err) _ = Invalid err
-  apply _ (Invalid err) = Invalid err
-  apply (Valid f) (Valid x) = Valid (f x)
+instance applyV :: Semiring err => Apply (V err)  where
+  apply (V (Left err1)) (V (Left err2)) = V (Left (err1 * err2))
+  apply (V (Left err)) _ = V (Left err)
+  apply _ (V (Left err)) = V (Left err)
+  apply (V (Right f)) (V (Right x)) = V (Right (f x))
 
-instance applicativeV :: (Semiring err) => Applicative (V err) where
-  pure = Valid
+instance applicativeV :: Semiring err => Applicative (V err) where
+  pure = V <<< Right
 
 instance semigroupV :: (Semiring err, Semigroup a) => Semigroup (V err a) where
   append = lift2 append
@@ -85,15 +91,15 @@ instance semigroupV :: (Semiring err, Semigroup a) => Semigroup (V err a) where
 instance monoidV :: (Semiring err, Monoid a) => Monoid (V err a) where
   mempty = pure mempty
 
-instance altV :: (Semiring err) => Alt (V err) where
-  alt (Invalid err1) (Invalid err2) = Invalid (err1 + err2)
-  alt (Invalid _) a = a
-  alt (Valid a) _ = Valid a
+instance altV :: Semiring err => Alt (V err) where
+  alt (V (Left err1)) (V (Left err2)) = V (Left (err1 + err2))
+  alt (V (Left _)) a = a
+  alt (V (Right a)) _ = V (Right a)
 
-instance plusV :: (Semiring err) => Plus (V err) where
-  empty = Invalid zero
+instance plusV :: Semiring err => Plus (V err) where
+  empty = V (Left zero)
 
-instance alernativeV :: (Semiring err) => Alternative (V err)
+instance alernativeV :: Semiring err => Alternative (V err)
 
 instance foldableV :: Foldable (V err) where
   foldMap = unV (const mempty)
@@ -101,5 +107,5 @@ instance foldableV :: Foldable (V err) where
   foldl f b = unV (const b) (f b)
 
 instance traversableV :: Traversable (V err) where
-  sequence = unV (pure <<< Invalid) (map Valid)
-  traverse f = unV (pure <<< Invalid) (map Valid <<< f)
+  sequence = unV (pure <<< V <<< Left) (map (V <<< Right))
+  traverse f = unV (pure <<< V <<< Left) (map (V <<< Right) <<< f)

--- a/src/Data/Validation/Semiring.purs
+++ b/src/Data/Validation/Semiring.purs
@@ -1,9 +1,6 @@
 -- | This module defines a variant of applicative validation with
--- | an `Alternative` instance, for validators which support errors
+-- | an `Alt` instance, for validators which support errors
 -- | with multiple alternatives.
--- |
--- | The API is equivalent to `Data.Validation`,
--- | but uses `Semiring` instead of `Semigroup`.
 module Data.Validation.Semiring
   ( V
   , unV
@@ -15,7 +12,6 @@ module Data.Validation.Semiring
 import Prelude
 
 import Control.Alt (class Alt)
-import Control.Alternative (class Alternative)
 import Control.Apply (lift2)
 import Control.Plus (class Plus)
 import Data.Bifunctor (class Bifunctor)
@@ -98,8 +94,6 @@ instance altV :: Semiring err => Alt (V err) where
 
 instance plusV :: Semiring err => Plus (V err) where
   empty = V (Left zero)
-
-instance alernativeV :: Semiring err => Alternative (V err)
 
 instance foldableV :: Foldable (V err) where
   foldMap = unV (const mempty)


### PR DESCRIPTION
@paf31 @MonoidMusician I've removed the `Alternative` instance for the `Semiring` version for now, as it is a valid `Plus` and it is a valid `Applicative`, it's just the interaction doesn't result in an `Alternative`. Seems a little dodgy still, but perhaps better than nothing until we come up with an alternative formulation.