### PR TITLE
Expose V constructors, resolves #11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,10 @@
     "purescript-control": "^4.0.0",
     "purescript-either": "^4.0.0",
     "purescript-foldable-traversable": "^4.0.0",
-    "purescript-prelude": "^4.0.0"
+    "purescript-prelude": "^4.0.0",
+    "purescript-newtype": "^3.0.0"
+  },
+  "devDependencies": {
+    "purescript-psci-support": "^4.0.0"
   }
 }

--- a/src/Data/Validation/Semigroup.purs
+++ b/src/Data/Validation/Semigroup.purs
@@ -5,7 +5,7 @@
 -- | `Either` terminates on the first error.
 
 module Data.Validation.Semigroup
-  ( V
+  ( V(..)
   , unV
   , invalid
   , isValid
@@ -21,6 +21,7 @@ import Data.Eq (class Eq1)
 import Data.Foldable (class Foldable)
 import Data.Ord (class Ord1)
 import Data.Traversable (class Traversable)
+import Data.Newtype (class Newtype)
 
 -- | The `V` functor, used for applicative validation
 -- |
@@ -37,6 +38,8 @@ import Data.Traversable (class Traversable)
 -- |   <*> validateEmail person.email
 -- | ```
 newtype V err result = V (Either err result)
+
+derive instance newtypeV :: Newtype (V err result) _
 
 -- | Unpack the `V` type constructor, providing functions to handle the error
 -- | and success cases.

--- a/src/Data/Validation/Semiring.purs
+++ b/src/Data/Validation/Semiring.purs
@@ -2,7 +2,7 @@
 -- | an `Alt` instance, for validators which support errors
 -- | with multiple alternatives.
 module Data.Validation.Semiring
-  ( V
+  ( V(..)
   , unV
   , invalid
   , isValid
@@ -20,6 +20,7 @@ import Data.Eq (class Eq1)
 import Data.Foldable (class Foldable)
 import Data.Ord (class Ord1)
 import Data.Traversable (class Traversable)
+import Data.Newtype (class Newtype)
 
 -- | The `V` functor, used for alternative validation
 -- |
@@ -38,6 +39,8 @@ import Data.Traversable (class Traversable)
 -- |   <*> (validateEmail person.contact <|> validatePhone person.contact)
 -- | ```
 newtype V err result = V (Either err result)
+
+derive instance newtypeV :: Newtype (V err result) _
 
 -- | Unpack the `V` type constructor, providing functions to handle the error
 -- | and success cases.


### PR DESCRIPTION
This is also relevant to #14 because exposing the constructor means that
you can implement the requested `valid` as `V <<< Right`.

I think this makes sense, because it's worthwhile to make converting between `Either` and `V` easy (and cheap), as there are use cases which involve wanting to make use of both the `Applicative (V e)` instance and the `Monad (Either e)` instance.

We might also want to consider deprecating `toEither`, as that can be recovered by `un V`.