### PR TITLE
Deprecate toEither

### DIFF
--- a/src/Data/Validation/Semigroup.purs
+++ b/src/Data/Validation/Semigroup.purs
@@ -23,6 +23,7 @@ import Data.Foldable (class Foldable)
 import Data.Ord (class Ord1)
 import Data.Traversable (class Traversable)
 import Data.Newtype (class Newtype)
+import Prim.TypeError (class Warn, Text)
 
 -- | The `V` functor, used for applicative validation
 -- |
@@ -57,7 +58,7 @@ isValid :: forall err result. V err result -> Boolean
 isValid (V (Right _)) = true
 isValid _ = false
 
-toEither :: forall err result. V err result -> Either err result
+toEither :: forall err result. Warn (Text "'toEither' is deprecated, pattern match on the constructor or use 'Data.Newtype.un V' instead") => V err result -> Either err result
 toEither (V e) = e
 
 -- | Apply a function if successful, to enable chaining of validation.

--- a/src/Data/Validation/Semiring.purs
+++ b/src/Data/Validation/Semiring.purs
@@ -22,6 +22,7 @@ import Data.Foldable (class Foldable)
 import Data.Ord (class Ord1)
 import Data.Traversable (class Traversable)
 import Data.Newtype (class Newtype)
+import Prim.TypeError (class Warn, Text)
 
 -- | The `V` functor, used for alternative validation
 -- |
@@ -58,7 +59,7 @@ isValid :: forall err result. V err result -> Boolean
 isValid (V (Right _)) = true
 isValid _ = false
 
-toEither :: forall err result. V err result -> Either err result
+toEither :: forall err result. Warn (Text "'toEither' is deprecated, pattern match on the constructor or use 'Data.Newtype.un V' instead") => V err result -> Either err result
 toEither (V e) = e
 
 -- | Apply a function if successful, to enable chaining of validation.


### PR DESCRIPTION
This pull request addresses the first part of https://github.com/purescript/purescript-validation/issues/23, deprecating Data.Validation.Semigroup.toEither and Data.Validation.Semiring.toEither so they can be removed in a future release.

